### PR TITLE
require yq 3.x

### DIFF
--- a/scripts/crd_build.sh
+++ b/scripts/crd_build.sh
@@ -97,7 +97,7 @@ then
                 
                 # check if we have any included stacks
                 included_stacks=$(yq r ${configfile} stack_groups[$group_count].repos[$url_count].include)
-                if [ ! "${included_stacks}" == "null" ]
+                if [ -n "${included_stacks}" ]
                 then
                     num_included=$(yq r ${configfile} stack_groups[$group_count].repos[$url_count].include | wc -l)
                     for ((included_count=0;included_count<$num_included;included_count++));
@@ -111,7 +111,7 @@ then
                 # check if we have any excluded stacks
                 declare -a excluded
                 excluded_stacks=$(yq r ${configfile} stack_groups[$group_count].repos[$url_count].exclude)
-                if [ ! "${excluded_stacks}" == "null" ]
+                if [ -n "${excluded_stacks}" ]
                 then
                     num_excluded=$(yq r ${configfile} stack_groups[$group_count].repos[$url_count].exclude | wc -l)
                     for ((excluded_count=0;excluded_count<$num_excluded;excluded_count++));

--- a/scripts/hub_build.sh
+++ b/scripts/hub_build.sh
@@ -21,7 +21,7 @@ exec_hooks() {
 
 update_image() {
     local image="$1"
-    if [ "${image}" != "null" ]
+    if [ -n "${image}" ]
     then
         IFS='/' read -a image_parts <<< "$image"
         len=${#image_parts[@]}
@@ -29,20 +29,20 @@ update_image() {
         then
             image_parts=("docker.io" "${image_parts[@]}")
         fi
-        if [ "${image_registry}" != "null" ]
+        if [ -n "${image_registry}" ]
         then
             image_parts[0]="${image_registry}"
         fi
-        if [ "${image_org}" != "null" ]
+        if [ -n "${image_org}" ]
         then
             image_parts[1]="${image_org}"
         fi
     else
-        if [ "${image_registry}" != "null" ]
+        if [ -n "${image_registry}" ]
         then
             image_parts[0]="${image_registry}"
         fi
-        if [ "${image_org}" != "null" ]
+        if [ -n "${image_org}" ]
         then
             image_parts[1]="${image_org}"
         fi
@@ -153,7 +153,7 @@ then
     image_registry=$(yq r ${configfile} image-registry)
     nginx_image_name=$(yq r ${configfile} nginx-image-name)
 
-    if [ "${image_org}" != "null" ] ||  [ "${image_registry}" != "null" ]
+    if [ -n "${image_org}" ] ||  [ -n "${image_registry}" ]
     then
         echo "Retrieving and modifying all the assets"
         export BUILD_ALL=true
@@ -167,16 +167,16 @@ then
 
     # Set the default image_org and image_registry values if they 
     # have not been set in the config file
-    if [ "${image_org}" == "null" ]
+    if [ -z "${image_org}" ]
     then
             image_org="appsody"
     fi
 
-    if [ "${image_registry}" == "null" ]
+    if [ -z "${image_registry}" ]
     then
             image_registry="docker.io"
     fi
-    
+
     # count the number of stacks in the index file
     num_stacks=$(yq r ${configfile} stacks[*].name | wc -l)
     if [ $num_stacks -gt 0 ] 
@@ -212,7 +212,7 @@ then
                 
                 # check if we have any included stacks
                 included_stacks=$(yq r ${configfile} stacks[$stack_count].repos[$url_count].include)
-                if [ ! "${included_stacks}" == "null" ]
+                if [ -n "${included_stacks}" ]
                 then
                     num_included=$(yq r ${configfile} stacks[$stack_count].repos[$url_count].include | wc -l)
                     for ((included_count=0;included_count<$num_included;included_count++));
@@ -226,7 +226,7 @@ then
                 # check if we have any excluded stacks
                 declare -a excluded
                 excluded_stacks=$(yq r ${configfile} stacks[$stack_count].repos[$url_count].exclude)
-                if [ ! "${excluded_stacks}" == "null" ]
+                if [ -n "${excluded_stacks}" ]
                 then
                     num_excluded=$(yq r ${configfile} stacks[$stack_count].repos[$url_count].exclude | wc -l)
                     for ((excluded_count=0;excluded_count<$num_excluded;excluded_count++));

--- a/scripts/install_yq.sh
+++ b/scripts/install_yq.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 cd /tmp
-curl -L -o yq_linux_amd64 https://github.com/mikefarah/yq/releases/download/2.4.1/yq_linux_amd64
+curl -L -o yq_linux_amd64 https://github.com/mikefarah/yq/releases/download/3.3.2/yq_linux_amd64
 sudo cp ./yq_linux_amd64 /usr/local/bin/yq
 sudo chmod 755 /usr/local/bin/yq
 

--- a/scripts/post_build.d/appsody_stacks/build_nginx.sh
+++ b/scripts/post_build.d/appsody_stacks/build_nginx.sh
@@ -52,7 +52,7 @@ then
         nginx_arg="--build-arg NGINX_IMAGE=$NGINX_IMAGE"
     fi
 
-    if [ "${nginx_image_name}" == "null" ] || [ "${nginx_image_name}" == "" ]
+    if [ -z "${nginx_image_name}" ]
     then
         nginx_image_name="stack-hub-index"
     fi

--- a/tests/appsody_stacks/run_appsody_tests.sh
+++ b/tests/appsody_stacks/run_appsody_tests.sh
@@ -53,7 +53,7 @@ for test_file in $test_dir/*_test.yaml; do
             # Get actual results
             assets_folder=$base_dir/assets/appsody_stacks
             build_folder=$base_dir/build/appsody_stacks
-            if [[ "$expected_image_registry" != null || "$expected_image_org" != null  ]]; then
+            if [[ -n "$expected_image_registry" || -n "$expected_image_org" ]]; then
                 result_file=$build_folder/index-src/$result_file_name
                 if [[ ! -f "$result_file" ]]; then
                     echo "No result file to insert overrides: $result_file"
@@ -106,7 +106,7 @@ for test_file in $test_dir/*_test.yaml; do
                 fi
             done
             # Check the image reistry and org are correct if overriden
-            if [[ "$expected_image_registry" != null || "$expected_image_org" != null  ]]; then
+            if [[ -n "$expected_image_registry" || -n "$expected_image_org" ]]; then
             for ((result_count=0;result_count<$results_stack_count;result_count++));
                 do
                     result_image=${image_paths[$result_count]}
@@ -119,14 +119,14 @@ for test_file in $test_dir/*_test.yaml; do
                     fi
                     result_reg=${image_parts[0]}
                     result_org=${image_parts[1]}
-                    if [[ "$expected_image_registry" != null ]]; then
+                    if [[ -n "$expected_image_registry" ]]; then
                         if [[ "$expected_image_registry" != "$result_reg" ]]; then
                             echo "Image registry mismatch, expected: $expected_image_registry, actual: $result_reg"
                             success="false"
                             break
                         fi
                     fi
-                    if [[ "$expected_image_org" != null ]]; then
+                    if [[ -n "$expected_image_org" ]]; then
                         if [[ "$expected_image_org" -ne "$result_org" ]]; then
                             echo "Image organisation mismatch, expected: $expected_image_org, actual: $result_org"
                             success="false"
@@ -136,7 +136,7 @@ for test_file in $test_dir/*_test.yaml; do
                 done
             fi
             # Check src url correctly updated
-            if [[ "$expected_image_registry" != null || "$expected_image_org" != null  ]]; then
+            if [[ -n "$expected_image_registry" || -n "$expected_image_org" ]]; then
             for ((result_count=0;result_count<$results_stack_count;result_count++));
                 do
                     result_src=${src_paths[$result_count]}


### PR DESCRIPTION
Fixes #11. Instead of supporting yq 2.x and 3.x, let's require and updated the code for yq 3.x.
