### PR TITLE
Ensure all tags get copied

### DIFF
--- a/scripts/hub_build.sh
+++ b/scripts/hub_build.sh
@@ -144,7 +144,7 @@ then
     mkdir -p ${assets_dir}
     mkdir -p ${build_dir}
 
-    rm -f $build_dir/image_list $build_dir/image-mapping.txt
+    rm -f $build_dir/image_list
 
     REPO_LIST=""
     INDEX_LIST=""

--- a/scripts/hub_deploy.sh
+++ b/scripts/hub_deploy.sh
@@ -37,7 +37,10 @@ image_push() {
 
 image_mirror() {
     local file=$1
-    oc image mirror -f "$file" --insecure ${oc_image_args[@]}
+    while IFS='=' read -r src_image dst_image
+    do
+        oc image mirror --insecure ${oc_image_args[@]} --filter-by-os='.*' "$src_image" "$dst_image"
+    done < $file
 }
 
 get_route() {


### PR DESCRIPTION
* For some reason `oc image mirror` doesn't always create all the tags when there are two tags that point to the same digest. So instead of passing a file with file mappings, call `oc image mirror` on each image separately.
* Ensure that rebuild still has all the image mappings.
