### PR TITLE
support local stacks

### DIFF
--- a/scripts/hub_build.sh
+++ b/scripts/hub_build.sh
@@ -364,7 +364,7 @@ then
                 if [ ! -z $BUILD ] && [ $BUILD == true ]
                 then
                     index_src=$build_dir/index-src/$(basename "$index_file_temp")
-                    sed -e "s|http.*:/.*/|{{EXTERNAL_URL}}/|" $index_file_temp > $index_src
+                    sed -e "s|http.*:/.*/|{{EXTERNAL_URL}}/|" -e "s|file:/.*/|{{EXTERNAL_URL}}/|" $index_file_temp > $index_src
                 fi
 
                 if [ "$CODEWIND_INDEX" == "true" ]
@@ -380,7 +380,7 @@ then
                             # flat json used by static appsody-index for codewind
                             index_src=$build_dir/index-src/$(basename "$codewind_file")
 
-                            sed -e "s|http.*/.*/|{{EXTERNAL_URL}}/|" $codewind_file > $index_src
+                            sed -e "s|http.*/.*/|{{EXTERNAL_URL}}/|" -e "s|file:/.*/|{{EXTERNAL_URL}}/|" $codewind_file > $index_src
                         done
                     fi
                 fi

--- a/scripts/hub_deploy.sh
+++ b/scripts/hub_deploy.sh
@@ -27,11 +27,7 @@ prereqs() {
 
 image_tag() {
     echo "== Tagging $@"
-    if [ "$docker_cmd" == "podman" ]; then
-        podman tag $1 $2
-    else
-        docker tag $1 $2
-    fi
+    $docker_cmd tag $1 $2
 }
 
 image_push() {

--- a/scripts/hub_deploy.sh
+++ b/scripts/hub_deploy.sh
@@ -25,6 +25,15 @@ prereqs() {
     command -v oc >/dev/null 2>&1 || { echo "Unable to mirror images or deploy stack-hub-index: oc is not installed."; exit 1; }
 }
 
+image_tag() {
+    echo "== Tagging $@"
+    if [ "$docker_cmd" == "podman" ]; then
+        podman tag $1 $2
+    else
+        docker tag $1 $2
+    fi
+}
+
 image_push() {
     local name=$@
     echo "== Pushing $name"
@@ -39,7 +48,12 @@ image_mirror() {
     local file=$1
     while IFS='=' read -r src_image dst_image
     do
-        oc image mirror --insecure ${oc_image_args[@]} --filter-by-os='.*' "$src_image" "$dst_image"
+        if [[ "$src_image" = "dev.local"* ]]; then
+            image_tag "$src_image" "$dst_image"
+            image_push "$dst_image"
+        else
+            oc image mirror --insecure ${oc_image_args[@]} --filter-by-os='.*' "$src_image" "$dst_image"
+        fi
     done < $file
 }
 


### PR DESCRIPTION
Enable stack `hub_build.sh`/`hub_deploy.sh` script work with locally built stacks.

For example, the `appsody_stack_config.yaml` can contain:
```
      - url: file:///home/me/.appsody/stacks/dev.local/dev.local-index.yaml
        include:
          - dotnet-api-server
```

This only works when building & deploying the stacks into the NGINX container hosted in a OpenShift cluster.
