### PR TITLE
Upgrade to java-openliberty v0.2.16

### DIFF
--- a/config/appsody_stack_config.yaml
+++ b/config/appsody_stack_config.yaml
@@ -10,7 +10,7 @@ stacks:
       - url: https://github.com/appsody/stacks/releases/download/quarkus-v0.5.1/incubator-index.yaml
         include: 
           - quarkus
-      - url: https://github.com/appsody/stacks/releases/download/java-openliberty-v0.2.15/incubator-index.yaml
+      - url: https://github.com/appsody/stacks/releases/download/java-openliberty-v0.2.16/incubator-index.yaml
         include: 
           - java-openliberty
 image-org:


### PR DESCRIPTION
Signed-off-by: Scott Kurz <skurz@us.ibm.com>

Depends on:
1. PR:  https://github.com/appsody/stacks/pull/858 being merged
2. The corresponding appsody/java-openliberty  v0.2.16 images being built and released to Docker Hub.