### PR TITLE
Add WebSphere Traditional Appsody Stack

### DIFF
--- a/config/appsody_stack_config.yaml
+++ b/config/appsody_stack_config.yaml
@@ -10,6 +10,7 @@ stacks:
       - url: https://github.com/appsody/stacks/releases/download/java-openliberty-v0.2.17/incubator-index.yaml
         include: 
           - java-openliberty
+      - url: https://github.com/WASdev/ci.stack.websphere-traditional/releases/download/v0.3.2/java-websphere-traditional-0.3.2-index.yaml
 image-org:
 image-registry:
 nginx-image-name:


### PR DESCRIPTION
Official images now hosted at docker.io/ibmcom/java-websphere-traditional