### PR TITLE
Remove pipelines-utils dependency

### DIFF
--- a/openshift/k8s.yaml
+++ b/openshift/k8s.yaml
@@ -21,14 +21,20 @@ spec:
       serviceAccountName: stack-hub-index
       initContainers:
       - name: init
-        image: INIT_IMAGE
+        image: NGINX_IMAGE
         command: ['/bin/sh']
         args:
           - -cex
           - |
+            APISERVER=https://kubernetes.default.svc
+            SERVICEACCOUNT=/var/run/secrets/kubernetes.io/serviceaccount
+            NAMESPACE=$(cat ${SERVICEACCOUNT}/namespace)
+            TOKEN=$(cat ${SERVICEACCOUNT}/token)
+            CACERT=${SERVICEACCOUNT}/ca.crt
             for i in 1 2 3 4 5 6 7 8 9 10; do
-              ROUTE=$(kubectl get route stack-hub-index --no-headers -o=jsonpath='{.status.ingress[0].host}')
-              if [ -z "$ROUTE" ]; then
+              ROUTE=$(curl --cacert ${CACERT} --header "Authorization: Bearer ${TOKEN}" -X GET -s \
+                           ${APISERVER}/apis/route.openshift.io/v1/namespaces/$NAMESPACE/routes/stack-hub-index | jq -r .status.ingress[0].host)
+              if [ -z "$ROUTE" ] || [ "$ROUTE" = "null" ]; then
                 sleep 1
               else
                 echo "http://$ROUTE" > /usr/share/stack-hub/route

--- a/scripts/hub_clean.sh
+++ b/scripts/hub_clean.sh
@@ -1,0 +1,10 @@
+#!/bin/bash -e
+
+script_dir=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
+base_dir=$(cd "${script_dir}/.." && pwd)
+
+echo
+echo "= Removing build and assets directories."
+echo
+
+rm -rf "${base_dir}/build" "${base_dir}/assets"

--- a/scripts/hub_deploy.sh
+++ b/scripts/hub_deploy.sh
@@ -72,7 +72,9 @@ prereqs
 
 # push nginx image
 if [ -f "$build_dir/image_list" ]; then
+    echo
     echo "= Pushing stack hub index image into your registry."
+    echo
     while read line
     do
         if [ "$line" != "" ]; then
@@ -83,13 +85,17 @@ fi
 
 # mirror stack images
 if [ -f "$build_dir/image-mapping.txt" ]; then
+    echo
     echo "= Mirroring stack and related images into your registry."
+    echo
     image_mirror "$build_dir/image-mapping.txt"
 fi 
 
 # deploy nginx container
 if [ -f "$build_dir/openshift.yaml" ]; then
+    echo
     echo "= Deploying stack hub index container into your cluster."
+    echo
     oc apply -f "$build_dir/openshift.yaml"
 
     INDEX_YAML=$(cd $build_dir/index-src && ls *-index.yaml | head -n 1)

--- a/scripts/nginx-ubi/Dockerfile
+++ b/scripts/nginx-ubi/Dockerfile
@@ -2,7 +2,7 @@ FROM registry.access.redhat.com/ubi8/ubi-minimal
 
 COPY nginx-ubi/nginx.repo  /etc/yum.repos.d/nginx.repo
 
-RUN microdnf install nginx findutils \
+RUN microdnf install nginx jq findutils \
     && mkdir /var/cache/nginx \
     && chown -R nginx:0 /var/log/nginx/ /var/cache/nginx /usr/share/nginx \
     && chmod -R g=u /var/log/nginx/ /var/cache/nginx /usr/share/nginx \

--- a/scripts/post_build.d/appsody_stacks/build_nginx.sh
+++ b/scripts/post_build.d/appsody_stacks/build_nginx.sh
@@ -14,17 +14,10 @@ image_build() {
 }
 
 openshift_deployment() {
-    SRC_INIT_IMAGE="docker.io/icp4apps/pipelines-utils:0.21.0-rc1"
-    INIT_IMAGE="$image_registry/$image_org/$(echo $SRC_INIT_IMAGE | cut -d'/' -f3)"
-
     YAML_FILE=$build_dir/openshift.yaml
     cp $base_dir/openshift/k8s.yaml $YAML_FILE
     sed -i -e "s|NGINX_IMAGE|$image_registry/$image_org/${nginx_image_name}:${INDEX_VERSION}|" $YAML_FILE
-    sed -i -e "s|INIT_IMAGE|$INIT_IMAGE|" $YAML_FILE
     sed -i -e "s|DATE|$(date -u '+%FT%TZ')|" $YAML_FILE
-
-    mapping_file=$build_dir/image-mapping.txt
-    grep -qxF "$SRC_INIT_IMAGE=$INIT_IMAGE" "$mapping_file" || echo "$SRC_INIT_IMAGE=$INIT_IMAGE" >> "$mapping_file"
 }
 
 if [ ! -z $BUILD ] && [ $BUILD == true ]


### PR DESCRIPTION
Remove dependency on a `pipelines-utils` image with `kubectl` command and instead use `curl` with `jq` to achieve the same. Also, add `hub_clean.sh` script to remove `build` and `assets` directory.
